### PR TITLE
新增切歌过渡动画

### DIFF
--- a/src/components/player/PlayerDetail.vue
+++ b/src/components/player/PlayerDetail.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { computed, onBeforeUnmount, ref, watch } from 'vue';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import { useLyrics } from '../../composables/lyrics';
 import { useSongDetailCache } from '../../composables/useSongDetailCache';
@@ -33,25 +33,6 @@ const currentSongDetail = ref<SongDetail | null>(null);
 let detailRequestId = 0;
 
 const appWindow = getCurrentWindow();
-
-const isFullscreen = ref(false);
-const wasMaximizedBeforeFullscreen = ref(false);
-let unlistenResize: (() => void) | null = null;
-
-const toggleFullscreen = async () => {
-  const currentFullscreen = await appWindow.isFullscreen();
-  if (!currentFullscreen) {
-    wasMaximizedBeforeFullscreen.value = await appWindow.isMaximized();
-    await appWindow.setFullscreen(true);
-    isFullscreen.value = true;
-  } else {
-    await appWindow.setFullscreen(false);
-    isFullscreen.value = false;
-    if (wasMaximizedBeforeFullscreen.value) {
-      await appWindow.maximize();
-    }
-  }
-};
 
 const minimize = () => appWindow.minimize();
 const toggleMaximize = async () => {
@@ -94,7 +75,7 @@ const handleTopChromeLeave = () => {
   scheduleTopChromeHide();
 };
 
-watch(showPlayerDetail, async (visible) => {
+watch(showPlayerDetail, (visible) => {
   clearTopChromeHideTimer();
 
   if (visible) {
@@ -106,13 +87,6 @@ watch(showPlayerDetail, async (visible) => {
   isTopChromeVisible.value = false;
   currentSongDetail.value = null;
   clearSongDetailCache();
-
-  // Exit fullscreen if we collapse the player details page
-  const isCurrentFullscreen = await appWindow.isFullscreen();
-  if (isCurrentFullscreen) {
-    await appWindow.setFullscreen(false);
-    isFullscreen.value = false;
-  }
 });
 
 watch([showPlayerDetail, () => currentSong.value?.path ?? ''], async ([visible, path]) => {
@@ -147,21 +121,8 @@ watch([showPlayerDetail, () => currentSong.value?.path ?? ''], async ([visible, 
   }
 }, { immediate: true });
 
-onMounted(async () => {
-  isFullscreen.value = await appWindow.isFullscreen();
-
-  // Listen to window resize to synchronize fullscreen state changes
-  const unlisten = await appWindow.listen('tauri://resize', async () => {
-    isFullscreen.value = await appWindow.isFullscreen();
-  });
-  unlistenResize = unlisten;
-});
-
 onBeforeUnmount(() => {
   clearTopChromeHideTimer();
-  if (unlistenResize) {
-    unlistenResize();
-  }
 });
 
 const formatFileSize = (size: number | undefined) => {
@@ -254,7 +215,6 @@ const metaInfo = computed(() => {
 
           <div class="relative z-10 flex w-1/4 items-center">
             <button
-              v-if="!isFullscreen"
               title="收起详情页"
               class="rounded-lg p-2 text-white/50 transition hover:bg-white/10 hover:text-white"
               @click="handleClose"
@@ -265,31 +225,15 @@ const metaInfo = computed(() => {
             </button>
           </div>
 
-          <div class="pointer-events-none flex-1 truncate px-4 text-center text-sm font-medium text-white/80 drop-shadow-md">
-            {{ currentSong?.title || currentSong?.name }}
-            <span v-if="currentSong?.artist" class="mx-1 opacity-60">-</span>
-            <span class="opacity-60">{{ currentSong?.artist }}</span>
-          </div>
+          <transition name="song-switch-text" mode="out-in">
+            <div :key="currentSong?.path" class="pointer-events-none flex-1 truncate px-4 text-center text-sm font-medium text-white/80 drop-shadow-md">
+              {{ currentSong?.title || currentSong?.name }}
+              <span v-if="currentSong?.artist" class="mx-1 opacity-60">-</span>
+              <span class="opacity-60">{{ currentSong?.artist }}</span>
+            </div>
+          </transition>
 
           <div class="relative z-10 flex w-1/4 items-center justify-end gap-2">
-            <button
-              :title="isFullscreen ? '退出沉浸模式' : '沉浸模式 (全屏)'"
-              class="rounded-lg p-2 text-white/50 transition hover:bg-white/10 hover:text-white"
-              @click="toggleFullscreen"
-            >
-              <svg v-if="isFullscreen" xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <polyline points="4 14 10 14 10 20" />
-                <polyline points="20 10 14 10 14 4" />
-                <line x1="14" y1="10" x2="21" y2="3" />
-                <line x1="10" y1="14" x2="3" y2="21" />
-              </svg>
-              <svg v-else xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <polyline points="15 3 21 3 21 9" />
-                <polyline points="9 21 3 21 3 15" />
-                <line x1="21" y1="3" x2="14" y2="10" />
-                <line x1="3" y1="21" x2="10" y2="14" />
-              </svg>
-            </button>
             <button class="rounded-lg p-2 text-white/50 transition hover:bg-white/10 hover:text-white" @click="minimize">
               <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <path d="M5 12h14" />
@@ -324,22 +268,24 @@ const metaInfo = computed(() => {
               class="h-full rounded-2xl border border-white/5 bg-black/10 p-4 shadow-xl backdrop-blur-sm"
             />
 
-            <LyricsView v-else-if="showPlayerDetail && parsedLyrics.length > 0" class="h-full" />
+            <LyricsView v-else-if="parsedLyrics.length > 0" class="h-full" />
 
-            <div
-              v-else
-              class="flex h-full flex-col items-center justify-center opacity-80"
-              style="text-shadow: 0 2px 10px rgba(0,0,0,0.4);"
-            >
+            <transition v-else name="song-switch-meta" mode="out-in">
               <div
-                v-for="(info, index) in metaInfo"
-                :key="index"
-                class="mb-4 flex items-center text-xl font-medium tracking-wider sm:text-2xl"
+                :key="currentSong?.path"
+                class="flex h-full flex-col items-center justify-center opacity-80"
+                style="text-shadow: 0 2px 10px rgba(0,0,0,0.4);"
               >
-                <span class="mr-4 text-white/40">{{ info.label }}</span>
-                <span class="text-white drop-shadow-md">{{ info.value }}</span>
+                <div
+                  v-for="(info, index) in metaInfo"
+                  :key="index"
+                  class="mb-4 flex items-center text-xl font-medium tracking-wider sm:text-2xl"
+                >
+                  <span class="mr-4 text-white/40">{{ info.label }}</span>
+                  <span class="text-white drop-shadow-md">{{ info.value }}</span>
+                </div>
               </div>
-            </div>
+            </transition>
           </transition>
         </div>
       </div>
@@ -357,6 +303,42 @@ const metaInfo = computed(() => {
 .fade-scale-leave-to {
   opacity: 0;
   transform: scale(0.97) translateY(10px);
+}
+
+/* 切歌时标题/歌手文字过渡 */
+.song-switch-text-enter-active,
+.song-switch-text-leave-active {
+  transition:
+    opacity 300ms cubic-bezier(0.4, 0, 0.2, 1),
+    transform 300ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.song-switch-text-enter-from {
+  opacity: 0;
+  transform: translateY(8px);
+}
+
+.song-switch-text-leave-to {
+  opacity: 0;
+  transform: translateY(-8px);
+}
+
+/* 切歌时歌曲元信息面板过渡 */
+.song-switch-meta-enter-active,
+.song-switch-meta-leave-active {
+  transition:
+    opacity 360ms cubic-bezier(0.4, 0, 0.2, 1),
+    transform 360ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.song-switch-meta-enter-from {
+  opacity: 0;
+  transform: translateY(16px) scale(0.98);
+}
+
+.song-switch-meta-leave-to {
+  opacity: 0;
+  transform: translateY(-12px) scale(0.98);
 }
 
 .text-shadow-sm {

--- a/src/components/player/PlayerDetailBackground.vue
+++ b/src/components/player/PlayerDetailBackground.vue
@@ -45,15 +45,17 @@ onUnmounted(() => {
       :style="{ backgroundColor: dominantColors[0] }"
     ></div>
 
-    <div v-if="thumbCoverUrl" class="absolute inset-0 overflow-hidden z-[1]">
-      <img
-        :src="thumbCoverUrl"
-        class="w-full h-full object-cover scale-110 select-none"
-        :style="{ filter: isLargeViewport ? 'blur(40px) brightness(0.78) saturate(1.42) contrast(1.16)' : 'blur(52px) brightness(0.72) saturate(1.36) contrast(1.14)' }"
-        draggable="false"
-        decoding="async"
-      />
-    </div>
+    <transition name="song-switch-bg" mode="out-in">
+      <div v-if="thumbCoverUrl" :key="thumbCoverUrl" class="absolute inset-0 overflow-hidden z-[1]">
+        <img
+          :src="thumbCoverUrl"
+          class="w-full h-full object-cover scale-110 select-none"
+          :style="{ filter: isLargeViewport ? 'blur(40px) brightness(0.78) saturate(1.42) contrast(1.16)' : 'blur(52px) brightness(0.72) saturate(1.36) contrast(1.14)' }"
+          draggable="false"
+          decoding="async"
+        />
+      </div>
+    </transition>
 
     <div class="absolute inset-0 z-[2]" :style="{ background: `radial-gradient(circle at 24% 16%, ${dominantColors[1] || dominantColors[0]}22 0%, transparent 52%)` }"></div>
     <div class="absolute inset-0 z-[3]" :style="{ background: `radial-gradient(circle at 78% 84%, ${dominantColors[2] || dominantColors[0]}18 0%, transparent 62%)` }"></div>
@@ -63,3 +65,16 @@ onUnmounted(() => {
     <div class="absolute inset-0 bg-gradient-to-b from-black/3 via-transparent to-black/22 z-20"></div>
   </div>
 </template>
+
+<style scoped>
+/* 切歌时背景封面交叉淡入淡出 */
+.song-switch-bg-enter-active,
+.song-switch-bg-leave-active {
+  transition: opacity 600ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.song-switch-bg-enter-from,
+.song-switch-bg-leave-to {
+  opacity: 0;
+}
+</style>

--- a/src/components/player/PlayerDetailLeft.vue
+++ b/src/components/player/PlayerDetailLeft.vue
@@ -175,13 +175,15 @@ defineExpose({ detailCoverRef });
       }"
     >
       <!-- Main Cover Container -->
-      <div class="w-full h-full rounded-[inherit] overflow-hidden relative isolate z-20">
-        <img v-if="currentLocalCoverUrl" :key="`thumb:${currentSongPath}:${currentLocalCoverUrl}`" :src="currentLocalCoverUrl" class="absolute inset-0 w-full h-full object-cover select-none transition-[transform,filter,opacity] duration-[240ms] ease-out z-10" :class="props.isExpanded ? (fullCoverLoading ? 'scale-[1.03] blur-[10px] brightness-90' : 'scale-100 blur-0 brightness-100') : 'scale-125 blur-0 brightness-100'" draggable="false" decoding="async" />
-        <img v-if="currentBigCoverUrl" :key="`big:${currentSongPath}:${currentBigCoverUrl}`" :src="currentBigCoverUrl" @load="onBigCoverLoad" @error="onBigCoverError" class="absolute inset-0 w-full h-full object-cover select-none transition-opacity duration-[240ms] ease-out z-20" :class="[props.isExpanded ? 'scale-100' : 'scale-125', bigCoverLoaded ? 'opacity-100' : 'opacity-0']" draggable="false" decoding="async" />
-        <div v-if="!currentLocalCoverUrl && !currentBigCoverUrl" class="absolute inset-0 w-full h-full bg-white/5 flex items-center justify-center text-white/10 z-0">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-32 w-32" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1" d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3" /></svg>
+      <transition name="song-switch-cover" mode="out-in">
+        <div :key="currentSongPath" class="w-full h-full rounded-[inherit] overflow-hidden relative isolate z-20">
+          <img v-if="currentLocalCoverUrl" :key="`thumb:${currentSongPath}:${currentLocalCoverUrl}`" :src="currentLocalCoverUrl" class="absolute inset-0 w-full h-full object-cover select-none transition-[transform,filter,opacity] duration-[240ms] ease-out z-10" :class="props.isExpanded ? (fullCoverLoading ? 'scale-[1.03] blur-[10px] brightness-90' : 'scale-100 blur-0 brightness-100') : 'scale-125 blur-0 brightness-100'" draggable="false" decoding="async" />
+          <img v-if="currentBigCoverUrl" :key="`big:${currentSongPath}:${currentBigCoverUrl}`" :src="currentBigCoverUrl" @load="onBigCoverLoad" @error="onBigCoverError" class="absolute inset-0 w-full h-full object-cover select-none transition-opacity duration-[240ms] ease-out z-20" :class="[props.isExpanded ? 'scale-100' : 'scale-125', bigCoverLoaded ? 'opacity-100' : 'opacity-0']" draggable="false" decoding="async" />
+          <div v-if="!currentLocalCoverUrl && !currentBigCoverUrl" class="absolute inset-0 w-full h-full bg-white/5 flex items-center justify-center text-white/10 z-0">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-32 w-32" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1" d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3" /></svg>
+          </div>
         </div>
-      </div>
+      </transition>
 
       <!-- Glass Table Reflection Layer -->
       <transition name="reflection-reveal" appear>
@@ -259,5 +261,23 @@ defineExpose({ detailCoverRef });
 
 .reflection-reveal-leave-to {
   transform: translateY(-10px) rotateX(48deg) skewX(-20deg) scale(0.985);
+}
+
+/* 切歌时封面交叉淡入淡出 */
+.song-switch-cover-enter-active,
+.song-switch-cover-leave-active {
+  transition:
+    opacity 360ms cubic-bezier(0.4, 0, 0.2, 1),
+    transform 360ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.song-switch-cover-enter-from {
+  opacity: 0;
+  transform: scale(1.05);
+}
+
+.song-switch-cover-leave-to {
+  opacity: 0;
+  transform: scale(0.98);
 }
 </style>


### PR DESCRIPTION
关联 Issue
Closes #77 

改动说明
- **新增切歌过渡动画**：优化了歌曲切换时的视觉体验，使界面过渡更加平滑。
- 优化了组件切换时的淡入淡出/位移效果
- 播放页左上角未增加置顶按钮 ！！！

测试与验证
- [x] 在切歌（上一首/下一首）时动画播放正常。
- [x] 快速连续切歌时，无动画卡死或状态错乱问题。