### PR TITLE
feat：优化搜索系统

### DIFF
--- a/src/components/layout/TitleBar.vue
+++ b/src/components/layout/TitleBar.vue
@@ -9,7 +9,7 @@ import { useSettings } from '../../features/settings/useSettings';
 
 const router = useRouter();
 const route = useRoute();
-const { searchQuery, setSearch, isMiniMode } = usePlayerViewState();
+const { searchQuery, setSearch, isMiniMode, currentViewMode } = usePlayerViewState();
 const appWindow = getCurrentWindow();
 const { settings } = useSettings();
 const { isDarkTheme, toggleThemeMode } = useThemeSettings();
@@ -17,6 +17,17 @@ const rotation = ref(0); // For settings icon animation
 const lastNonSettingsRoute = ref(route.path === '/settings' ? '/' : route.fullPath);
 const isSettingsRoute = computed(() => route.path === '/settings');
 const themeToggleTitle = computed(() => (isDarkTheme.value ? '切换浅色' : '切换深色'));
+
+// 搜索框提示文字随页面切换：歌曲/艺术家/专辑三种搜索模式
+const searchPlaceholder = computed(() => {
+  if (route.path === '/artists') {
+    return '搜索艺术家...';
+  }
+  if (route.path === '/albums') {
+    return '搜索专辑...';
+  }
+  return '搜索歌曲...';
+});
 
 const rotateSettings = () => {
   rotation.value += 180;
@@ -41,6 +52,14 @@ watch(
     }
   },
   { immediate: true },
+);
+
+// 切换页面或首页子视图（本地音乐/文件夹/统计等）时清空搜索词，避免过滤条件残留
+watch(
+  [() => route.path, currentViewMode],
+  () => {
+    setSearch('');
+  },
 );
 
 // 最小化
@@ -93,7 +112,7 @@ const goBack = () => { router.back(); };
         </svg>
         <input 
           type="text" 
-          placeholder="搜索音乐..." 
+          :placeholder="searchPlaceholder" 
           class="bg-transparent outline-none w-full placeholder-gray-700 dark:placeholder-gray-300 text-gray-800 dark:text-gray-100 text-xs font-medium"
           :value="searchQuery"
           @input="handleInput"

--- a/src/components/song-list/SongTable.vue
+++ b/src/components/song-list/SongTable.vue
@@ -617,7 +617,8 @@ const getRowStyle = (songIndex: number, songPath: string) => {
       :class="{ 'song-list-scrollbar-active': isScrollbarActive }"
       @scroll="onScroll"
     >
-      <div class="w-full relative">
+      <Transition name="search-refresh">
+        <div :key="`song-list-${searchQuery.trim()}`" class="w-full relative">
         <div :style="{ height: virtualPaddingTop }"></div>
 
         <div
@@ -723,6 +724,7 @@ const getRowStyle = (songIndex: number, songPath: string) => {
 
         <div :style="{ height: virtualPaddingBottom }"></div>
       </div>
+      </Transition>
 
       <div v-if="songs.length === 0" class="py-20 flex flex-col justify-center items-center select-none text-gray-500 dark:text-white/60">
         <template v-if="showLibraryOnboarding || showFolderEmpty || hasSearchQuery">
@@ -887,6 +889,16 @@ const getRowStyle = (songIndex: number, songPath: string) => {
 </template>
 
 <style scoped>
+/* 搜索结果刷新过渡：新列表淡入上移，旧列表立即移除保持实时 */
+.search-refresh-enter-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.search-refresh-enter-from {
+  opacity: 0;
+  transform: translateY(8px);
+}
+
 .song-list-scroll-container {
   overflow-anchor: none;
   scrollbar-color: rgba(0, 0, 0, 0.16) transparent;

--- a/src/views/Albums.vue
+++ b/src/views/Albums.vue
@@ -673,8 +673,10 @@ onUnmounted(() => {
         </div>
       </div>
 
+      <Transition name="search-refresh">
       <div
         v-if="albumSortMode === 'name'"
+        :key="`album-grouped-${searchQuery.trim()}`"
         :style="{ paddingTop: groupedAlbumVirtualState.paddingTop, paddingBottom: groupedAlbumVirtualState.paddingBottom }"
       >
         <template v-for="row in groupedAlbumVirtualState.rows" :key="row.key">
@@ -751,6 +753,7 @@ onUnmounted(() => {
 
       <div
         v-else
+        :key="`album-flat-${searchQuery.trim()}`"
         class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-7 gap-x-6 gap-y-10"
         :style="{ paddingTop: flatAlbumVirtualState.paddingTop, paddingBottom: flatAlbumVirtualState.paddingBottom }"
       >
@@ -807,11 +810,22 @@ onUnmounted(() => {
           </div>
         </div>
       </div>
+      </Transition>
     </section>
   </div>
 </template>
 
 <style scoped>
+/* 搜索结果刷新过渡：新列表淡入上移，旧列表立即移除保持实时 */
+.search-refresh-enter-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.search-refresh-enter-from {
+  opacity: 0;
+  transform: translateY(8px);
+}
+
 .albums-scroll-container {
   overflow-anchor: none;
 }

--- a/src/views/Artists.vue
+++ b/src/views/Artists.vue
@@ -645,8 +645,10 @@ onUnmounted(() => {
         </div>
       </div>
 
+      <Transition name="search-refresh">
       <div
         v-if="artistSortMode === 'name'"
+        :key="`artist-grouped-${searchQuery.trim()}`"
         :style="{ paddingTop: groupedArtistVirtualState.paddingTop, paddingBottom: groupedArtistVirtualState.paddingBottom }"
       >
         <template v-for="row in groupedArtistVirtualState.rows" :key="row.key">
@@ -702,6 +704,7 @@ onUnmounted(() => {
 
       <div
         v-else
+        :key="`artist-flat-${searchQuery.trim()}`"
         class="grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-x-6 gap-y-4"
         :style="{ paddingTop: flatArtistVirtualState.paddingTop, paddingBottom: flatArtistVirtualState.paddingBottom }"
       >
@@ -737,11 +740,22 @@ onUnmounted(() => {
           </div>
         </div>
       </div>
+      </Transition>
     </section>
   </div>
 </template>
 
 <style scoped>
+/* 搜索结果刷新过渡：新列表淡入上移，旧列表立即移除保持实时 */
+.search-refresh-enter-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.search-refresh-enter-from {
+  opacity: 0;
+  transform: translateY(8px);
+}
+
 .artists-scroll-container {
   overflow-anchor: none;
 }


### PR DESCRIPTION
## 概述
- **搜索框提示文字动态化**：提示文字随页面切换为「搜索歌曲/搜索艺术家/搜索专辑」三种模式
- **切换时自动清空搜索词**：切换页面或首页子视图时清空搜索输入，避免过滤条件跨视图残留，播放详情页除外
- **搜索刷新过渡动画**：为歌曲、艺术家、专辑列表的实时搜索刷新加入过渡动画，消除结果更新时的生硬跳变

## 变更类型
- [x] 功能增强

## 详情
- `TitleBar.vue` — 搜索框提示文字动态化：
  - 新增 `searchPlaceholder` computed，按路由生成提示文字——`/artists` 显示「搜索艺术家...」、`/albums` 显示「搜索专辑...」，其余歌曲列表页面显示「搜索歌曲...」，替换原先固定的「搜索音乐...」
  - 判断依据选用 `route.path` 而非 `currentViewMode`，因为进入艺术家/专辑路由时视图模式不会被改写
- `TitleBar.vue` — 切换时清空搜索词：
  - 新增 watch 监听 `route.path` 与 `currentViewMode` 两个维度，任一变化即 `setSearch('')`
  - `route.path` 覆盖收藏/最近播放/歌手/专辑/设置等页面切换；`currentViewMode` 覆盖首页内部子视图切换及歌手/专辑详情钻取
- `SongTable.vue` — 歌曲列表搜索刷新过渡：
  - 列表外层包裹 `<Transition name="search-refresh">`，以 `searchQuery.trim()` 作为 key 触发重渲染，搜索刷新时新列表淡入上移
  - 该组件被本地音乐、收藏、最近播放三个页面复用，覆盖全部歌曲搜索
- `Artists.vue` / `Albums.vue` — 艺术家/专辑网格搜索刷新过渡：
  - 对分组/平铺两种排序分支同样包裹 `<Transition name="search-refresh">`；虚拟滚动容器与滚动位置在过渡外层，不受动画重置影响
- 过渡仅定义入场动画（`opacity 0.2s ease` + `translateY 8px`），旧列表立即移除，保证搜索结果实时呈现、不被动画延迟
- 封面懒加载依赖 `visibleArtistCoverPaths` 的 `flush: 'post'` watch 重新初始化 IntersectionObserver，搜索重渲染后自动恢复，无失效问题

## 测试
- [x] 前端测试全部通过（74 文件 / 486 tests）
- [x] TypeScript 类型检查通过
- [x] ESLint 通过（改动的 4 个文件）

## 相关 Issue
暂无

## 其他
第一次给大佬项目提 PR ，希望以后能够继续为 Lycia 做些贡献 (ᐡ⦁⩊⦁⸝⸝ᐡ )₊୭
